### PR TITLE
Use bintray React Native mirror

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ repositories {
     google()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "https://unpkg.com/react-native@0.57.5/android"
+        url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/"
     }
     maven {
         url 'https://maven.google.com/'
@@ -50,6 +50,11 @@ repositories {
 }
 
 dependencies {
-    //noinspection GradleDynamicVersion
-    implementation 'com.facebook.react:react-native:+'
+    if (project == rootProject) {
+        // If this is the root project (e.g. Jitpack), specify a version
+        implementation 'com.facebook.react:react-native:0.57.5'
+    } else {
+        //noinspection GradleDynamicVersion
+        implementation 'com.facebook.react:react-native:+'
+    }
 }


### PR DESCRIPTION
Updating `feature/enable-android-build-of-standalone-package` to use the Bintray repo.