### PR TITLE
Update version in package.json to avoid caching problems

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license          = package['license']
   s.homepage         = 'https://github.com/react-native-community/react-native-svg'
   s.authors          = 'Horcrux Chen'
-  s.source           = { :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => s.version }
+  s.source           = { :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => s.version }
   s.source_files     = 'ios/**/*.{h,m}'
   s.requires_arc     = true
   s.platforms        = { :ios => "8.0", :tvos => "9.2" }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.3.3",
+    "version": "9.3.3-gb",
     "name": "react-native-svg",
     "description": "SVG library for react-native",
     "repository": {


### PR DESCRIPTION
The recent podspec changes are working well but since there was no version change CocoaPods can get mixed up and use the cached old version. The simply bumps the version to avoid that (podspec version comes from package.json).